### PR TITLE
#16 gabrielvictorcf rust tree solutions

### DIFF
--- a/rust/trees/0094-binary-tree-inorder-traversal.rs
+++ b/rust/trees/0094-binary-tree-inorder-traversal.rs
@@ -1,0 +1,39 @@
+// Threaded Binary Tree / Morris Traversal
+use std::rc::Rc;
+use std::cell::RefCell;
+impl Solution {
+    pub fn inorder_traversal(mut root: Option<Rc<RefCell<TreeNode>>>) -> Vec<i32> {
+        let mut visited = vec![];
+        while root.is_some() {
+            let root_rc = root.clone().unwrap();
+            let root_ref = root_rc.borrow();
+
+            if root_ref.left.is_some() {
+                let mut pre = root_ref.left.clone();
+                loop {
+                    let pre_rc = pre.clone().unwrap();
+                    let p_ref = pre_rc.borrow();
+                    if p_ref.right.is_none() || p_ref.right == root {break};
+
+                    pre = p_ref.right.clone();
+                }
+
+                let mut pre = pre.unwrap();
+                let mut pre = pre.borrow_mut();
+                if pre.right.is_none() {
+                    pre.right = root.clone();
+                    root = root_ref.left.clone();
+                } else {
+                    pre.right = None;
+                    visited.push(root_ref.val);
+                    root = root_ref.right.clone();
+                }
+            } else {
+                visited.push(root_ref.val);
+                root = root_ref.right.clone();
+            }
+        }
+
+        visited
+    }
+}

--- a/rust/trees/0098-valid-binary-search-tree.rs
+++ b/rust/trees/0098-valid-binary-search-tree.rs
@@ -1,0 +1,43 @@
+// Definition for a binary tree node.
+// #[derive(Debug, PartialEq, Eq)]
+// pub struct TreeNode {
+//   pub val: i32,
+//   pub left: Option<Rc<RefCell<TreeNode>>>,
+//   pub right: Option<Rc<RefCell<TreeNode>>>,
+// }
+// 
+// impl TreeNode {
+//   #[inline]
+//   pub fn new(val: i32) -> Self {
+//     TreeNode {
+//       val,
+//       left: None,
+//       right: None
+//     }
+//   }
+// }
+use std::rc::Rc;
+use std::cell::RefCell;
+impl Solution {
+    fn inorder(root: Option<Rc<RefCell<TreeNode>>>, prev: &mut Option<i32>) -> bool {
+        if root.is_none() {return true};
+        let root = root.unwrap();
+        let root = root.borrow();
+        
+        let left_valid = Self::inorder(root.left.clone(), prev);
+
+        if let Some(prev_val) = prev {
+            if *prev_val >= root.val {return false};
+        }
+        *prev = Some(root.val);
+
+        let right_valid = Self::inorder(root.right.clone(), prev);
+
+        left_valid && right_valid
+    }
+
+    pub fn is_valid_bst(root: Option<Rc<RefCell<TreeNode>>>) -> bool {
+        let mut prev = None;
+        Self::inorder(root, &mut prev)
+    }
+}

--- a/rust/trees/0102-binary-tree-level-order-traversal.rs
+++ b/rust/trees/0102-binary-tree-level-order-traversal.rs
@@ -1,0 +1,46 @@
+// Definition for a binary tree node.
+// #[derive(Debug, PartialEq, Eq)]
+// pub struct TreeNode {
+//   pub val: i32,
+//   pub left: Option<Rc<RefCell<TreeNode>>>,
+//   pub right: Option<Rc<RefCell<TreeNode>>>,
+// }
+// 
+// impl TreeNode {
+//   #[inline]
+//   pub fn new(val: i32) -> Self {
+//     TreeNode {
+//       val,
+//       left: None,
+//       right: None
+//     }
+//   }
+// }
+use std::rc::Rc;
+use std::cell::RefCell;
+use std::collections::VecDeque;
+impl Solution {
+    pub fn level_order(root: Option<Rc<RefCell<TreeNode>>>) -> Vec<Vec<i32>> {
+        if root.is_none() {return vec![]};
+
+        let mut levels = vec![];
+        let mut to_visit = VecDeque::from([(root.unwrap(), 0)]);
+        while let Some((node, level)) = to_visit.pop_front() {
+            let mut node = node.borrow_mut();
+
+            if level >= levels.len() {
+                levels.push(vec![node.val]);
+            } else {
+                levels[level].push(node.val);
+            }
+
+            for child in [node.left.take(), node.right.take()] {
+                if child.is_none() {continue};
+
+                to_visit.push_back((child.unwrap(), level+1));
+            }
+        }
+
+        levels
+    }
+}

--- a/rust/trees/0103-binary-tree-zigzag-level-order-traversal.rs
+++ b/rust/trees/0103-binary-tree-zigzag-level-order-traversal.rs
@@ -1,0 +1,62 @@
+// Definition for a binary tree node.
+// #[derive(Debug, PartialEq, Eq)]
+// pub struct TreeNode {
+//   pub val: i32,
+//   pub left: Option<Rc<RefCell<TreeNode>>>,
+//   pub right: Option<Rc<RefCell<TreeNode>>>,
+// }
+// 
+// impl TreeNode {
+//   #[inline]
+//   pub fn new(val: i32) -> Self {
+//     TreeNode {
+//       val,
+//       left: None,
+//       right: None
+//     }
+//   }
+// }
+use std::rc::Rc;
+use std::cell::RefCell;
+use std::collections::VecDeque;
+impl Solution {
+    pub fn zigzag_level_order(root: Option<Rc<RefCell<TreeNode>>>) -> Vec<Vec<i32>> {
+        if root.is_none() {return vec![]};
+
+        let mut levels = vec![];
+        let mut to_visit = VecDeque::from([root.unwrap()]);
+        while !to_visit.is_empty() {
+            let mut level = vec![];
+            let mut is_zig = levels.len()%2 == 0;
+            if is_zig { // left to right level traversal
+                for _ in 0..to_visit.len() {
+                    let node = to_visit.pop_front().unwrap();
+                    let node = node.borrow();
+
+                    level.push(node.val);
+                    for child in [node.left.clone(), node.right.clone()] {
+                        if child.is_none() {continue};
+
+                        to_visit.push_back(child.unwrap());
+                    }
+                }
+            } else { // right to left level traversal
+                for _ in 0..to_visit.len() {
+                    let node = to_visit.pop_back().unwrap();
+                    let node = node.borrow();
+
+                    level.push(node.val);
+                    for child in [node.right.clone(), node.left.clone()] {
+                        if child.is_none() {continue};
+
+                        to_visit.push_front(child.unwrap());
+                    }
+                }
+            }
+
+            levels.push(level);
+        }
+
+        levels
+    }
+}

--- a/rust/trees/0105-construct-binary-tree-from-preorder-and-inorder-traversal.rs
+++ b/rust/trees/0105-construct-binary-tree-from-preorder-and-inorder-traversal.rs
@@ -1,0 +1,45 @@
+// Definition for a binary tree node.
+// #[derive(Debug, PartialEq, Eq)]
+// pub struct TreeNode {
+//   pub val: i32,
+//   pub left: Option<Rc<RefCell<TreeNode>>>,
+//   pub right: Option<Rc<RefCell<TreeNode>>>,
+// }
+// 
+// impl TreeNode {
+//   #[inline]
+//   pub fn new(val: i32) -> Self {
+//     TreeNode {
+//       val,
+//       left: None,
+//       right: None
+//     }
+//   }
+// }
+use std::rc::Rc;
+use std::cell::RefCell;
+use std::collections::HashMap;
+type Tnode = Option<Rc<RefCell<TreeNode>>>;
+impl Solution {
+    pub fn build_node(preorder: &[i32], tree: &[i32], inorder_map: &HashMap<i32, usize>) -> Tnode {
+        if preorder.is_empty() || tree.is_empty() {return None};
+
+        let root_val = preorder[0];
+        let tree_start = inorder_map[&tree[0]];
+        let root_i = inorder_map[&root_val] - tree_start;
+        let mut val_node = TreeNode::new(root_val);
+
+        let left_subtree = &tree[0..root_i];
+        let right_subtree = &tree[root_i+1..tree.len()];
+
+        val_node.left = Self::build_node(&preorder[1..], left_subtree, inorder_map);
+        val_node.right = Self::build_node(&preorder[left_subtree.len()+1..], right_subtree, inorder_map);
+
+        Some(Rc::new(RefCell::new(val_node)))
+    }
+
+    pub fn build_tree(preorder: Vec<i32>, inorder: Vec<i32>) -> Option<Rc<RefCell<TreeNode>>> {
+        let inorder_map: HashMap<i32, usize> = inorder.iter().enumerate().map(|(i, n)| (*n, i)).collect();
+        Self::build_node(&preorder, &inorder, &inorder_map)
+    }
+}

--- a/rust/trees/0108-convert-sorted-array-to-bynary-search-tree.rs
+++ b/rust/trees/0108-convert-sorted-array-to-bynary-search-tree.rs
@@ -1,0 +1,38 @@
+// Definition for a binary tree node.
+// #[derive(Debug, PartialEq, Eq)]
+// pub struct TreeNode {
+//   pub val: i32,
+//   pub left: Option<Rc<RefCell<TreeNode>>>,
+//   pub right: Option<Rc<RefCell<TreeNode>>>,
+// }
+// 
+// impl TreeNode {
+//   #[inline]
+//   pub fn new(val: i32) -> Self {
+//     TreeNode {
+//       val,
+//       left: None,
+//       right: None
+//     }
+//   }
+// }
+use std::rc::Rc;
+use std::cell::RefCell;
+impl Solution {
+    fn to_tree(tree: &[i32]) -> Option<Rc<RefCell<TreeNode>>> {
+        if tree.is_empty() {return None};
+
+        let mid = tree.len()/2;
+        let val = tree[mid];
+        let mut root = TreeNode::new(val);
+
+        root.left = Self::to_tree(&tree[0..mid]);
+        root.right = Self::to_tree(&tree[mid+1..tree.len()]);
+
+        Some(Rc::new(RefCell::new(root)))
+    }
+
+    pub fn sorted_array_to_bst(nums: Vec<i32>) -> Option<Rc<RefCell<TreeNode>>> {
+        Self::to_tree(&nums)
+    }
+}

--- a/rust/trees/0116-populating-next-right-pointers-in-each-node.rs
+++ b/rust/trees/0116-populating-next-right-pointers-in-each-node.rs
@@ -1,0 +1,83 @@
+// As of this publishing, Leetcode has not implemented this
+// problem for rust - definitions may differ
+// Definition for a binary tree node.
+#[derive(Debug, PartialEq, Eq)]
+pub struct TreeNode {
+  pub val: i32,
+  pub left: Option<Rc<RefCell<TreeNode>>>,
+  pub right: Option<Rc<RefCell<TreeNode>>>,
+  pub next: Option<Rc<RefCell<TreeNode>>>,
+}
+
+impl TreeNode {
+  #[inline]
+  pub fn new(val: i32) -> Self {
+    TreeNode {
+      val,
+      left: None,
+      right: None,
+      next: None
+    }
+  }
+}
+
+pub struct Solution();
+
+use std::rc::Rc;
+use std::cell::RefCell;
+impl Solution {
+    pub fn connect(root: Option<Rc<RefCell<TreeNode>>>) -> Option<Rc<RefCell<TreeNode>>> {
+        let mut node = root.clone();
+        while node.is_some() {
+            let mut cur = node.clone();
+            while let Some(parent) = cur {
+                let parent = parent.borrow();
+                if parent.left.is_none() {break};
+
+                let left = parent.left.clone().unwrap();
+                let mut left = left.borrow_mut();
+                left.next = parent.right.clone();
+                if let Some(nx) = parent.next.clone() {
+                    let nx = nx.borrow();
+                    
+                    let right = parent.right.clone().unwrap();
+                    let mut right = right.borrow_mut();
+                    right.next = nx.left.clone();
+                }
+
+                cur = parent.next.clone();
+            }
+
+            let n = node.unwrap();
+            node = n.borrow().left.clone();
+        }
+
+        root
+    }
+}
+
+fn main() {
+    let mut rt = TreeNode::new(1);
+    
+    let mut l = TreeNode::new(2);
+    let mut ll = TreeNode::new(4);
+    let mut lr = TreeNode::new(5);
+
+    let mut r = TreeNode::new(3);
+    let mut rl = TreeNode::new(6);
+    let mut rr = TreeNode::new(7);
+
+    r.left = Some(Rc::new(RefCell::new(rl)));
+    r.right = Some(Rc::new(RefCell::new(rr)));
+
+    l.left = Some(Rc::new(RefCell::new(ll)));
+    l.right = Some(Rc::new(RefCell::new(lr)));
+    
+    rt.left = Some(Rc::new(RefCell::new(l)));
+    rt.right = Some(Rc::new(RefCell::new(r)));
+
+    let rt = Some(Rc::new(RefCell::new(rt)));
+    println!("{:#?}", rt.clone());
+    Solution::connect(rt.clone());
+    println!("{:#?}", rt.clone());
+}


### PR DESCRIPTION
This PR closes issue https://github.com/gosiqueira/leetcode-ebbinghaus-practice/issues/16 with tested solutions.

One singular exception is the case of exercise `#0116-populating-next-right-pointers-in-each-node` which, _as of the time i'm writing this PR_, is not implemented by Leetcode. I've changed the `TreeNode` struct definition to accomodate the next pointer in the way i imagine they'll implement it in the future. In the end, the solution compiles and has a (kind of) test case in it.